### PR TITLE
Supporting GCC 6.0

### DIFF
--- a/Front/lib.cpp
+++ b/Front/lib.cpp
@@ -286,6 +286,9 @@ bool
 AutLib::fileExists(char *filename)
 {
   // check file exists
-  std::ifstream s(filename);
-  return s != 0;
+  std::ifstream s;
+  s.open(filename);
+  if (!s)
+    return false;
+  return true;
 }


### PR DESCRIPTION
Debian build fail for experimental GCC 6.0. - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811842
The proposed fix is added.