### PR TITLE
Front/ast.cpp: copy formal arguments when creating Code_Import

### DIFF
--- a/Front/ast.cpp
+++ b/Front/ast.cpp
@@ -1825,7 +1825,12 @@ ASTForm_Import::makeCode(SubstCode *subst)
       actuals->push_back(*i); // no substitution
   }
 
-  return codeTable->insert(new Code_Import(file, fileVars, actuals, pos));
+  Deque<char*> *newForms = new Deque<char*>;
+  for (Deque<char*>::iterator it = fileVars->begin(); it != fileVars->end(); ++it) {
+    newForms->push_back(*it);
+  }
+
+  return codeTable->insert(new Code_Import(file, newForms, actuals, pos));
 }
 
 VarCode


### PR DESCRIPTION
This fixes a bug which emerged when an import was used in a predicate
called from more than one place.  After the first use, the formal
arguments of the import were deleted and the second access was reading
invalid memory, which resulted in segmentation fault (attaching faulty inputs).

The fix copies the formal arguments for every instance of the import.
Note that a small memory leak (of the original formal arguments) may
have been introduced.

[mona-import-formals-error.zip](https://github.com/cs-au-dk/MONA/files/2320754/mona-import-formals-error.zip)